### PR TITLE
tasksgraphs: fix parent task row

### DIFF
--- a/src/components/tasksgraph.vue
+++ b/src/components/tasksgraph.vue
@@ -205,8 +205,25 @@ export default {
         return levelTasks;
       };
 
+      let levelsTasks = function(tasks, startLevel) {
+        let levelTasks = [];
+        for (let task of tasks) {
+          if (task.level < startLevel) {
+            continue;
+          }
+          levelTasks.push(task);
+        }
+        return levelTasks;
+      };
+
       let levelTasksByRow = function(tasks, level) {
         return levelTasks(tasks, level).sort((a, b) =>
+          a.row > b.row ? 1 : b.row > a.row ? -1 : 0
+        );
+      };
+
+      let levelsTasksByRow = function(tasks, startLevel) {
+        return levelsTasks(tasks, startLevel).sort((a, b) =>
           a.row > b.row ? 1 : b.row > a.row ? -1 : 0
         );
       };
@@ -254,7 +271,7 @@ export default {
         let row = 0;
         // if not at the last level fetch parents by their childs
         if (l < maxlevel) {
-          for (let curTask of levelTasksByRow(graphTasks, l + 1)) {
+          for (let curTask of levelsTasksByRow(graphTasks, l + 1)) {
             for (let depTaskID in curTask.depends) {
               for (let parent of levelTasks(graphTasks, l)) {
                 if (seenTasks.has(parent.id)) {
@@ -266,7 +283,7 @@ export default {
                   let maxChildLevel = taskMaxChildLevel(graphTasks, parent);
                   if (maxChildLevel > parent.level + 1) {
                     // put parent in a row greater than the max row the next levels until the child level
-                    let mrow = levelsMaxRow(graphTasks, maxChildLevel) + 1;
+                    let mrow = levelsMaxRow(graphTasks, maxChildLevel - 1) + 1;
                     parent.row = mrow;
                     row = mrow + 1;
                   } else {


### PR DESCRIPTION
* Consider all the tasks from the current level + 1 when fetching the parents
tasks

* Exclude the child level when computing the parent row needed to create an edge
that don't overlaps with the tasks of greater level.