### PR TITLE
Update package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agola-web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Even if not required package version should be aligned to git tag/release version.
If you build from the latest tagged release (v0.2.0) you get this output:
```
$ npm run build

> agola-web@0.1.0 build /src/agola-web
> vue-cli-service build
<...>
```
Not a real issue but a little bit confusing.