### PR TITLE
views: make tab elements wrap to new line

### DIFF
--- a/src/components/tabarrow.vue
+++ b/src/components/tabarrow.vue
@@ -1,7 +1,11 @@
 <template>
-  <div class="arrow">
-    <svg viewBox="0 0 15 15">
-      <path fill="none" stroke="#9d9d9d" d="M4.32.5l6.247 6.942L4.32 14.5"></path>
+  <div class="pr-4">
+    <svg class="arrow inline-block" viewBox="0 0 15 15">
+      <path
+        fill="none"
+        stroke="#9d9d9d"
+        d="M4.32.5l6.247 6.942L4.32 14.5"
+      ></path>
     </svg>
   </div>
 </template>
@@ -15,9 +19,5 @@ export default {
 <style scoped lang="scss">
 .arrow {
   width: 1.2em;
-  height: 1.4em;
-  align-items: center;
-  position: relative;
-  top: 0.1rem;
 }
 </style>

--- a/src/css/tailwind.scss
+++ b/src/css/tailwind.scss
@@ -34,11 +34,11 @@
 }
 
 .tab {
-  @apply flex border-b-2;
+  @apply flex;
 }
 
 .tab-element {
-  @apply px-4 -m-2px border-b-2;
+  @apply pr-4;
 }
 
 .tab-element:hover {
@@ -46,11 +46,11 @@
 }
 
 .tab-element-selected {
-  @apply border-b-2 border-blue-300 text-blue-500;
+  @apply border-blue-300 text-blue-500;
 }
 
 .tab-element-disabled {
-  @apply px-4 -m-2px border-b-2;
+  @apply pr-4;
 }
 
 .panel {

--- a/src/views/Project.vue
+++ b/src/views/Project.vue
@@ -1,135 +1,202 @@
 <template>
   <div>
-    <projbreadcrumbs :ownertype="ownertype" :ownername="ownername" :projectref="projectref" />
+    <projbreadcrumbs
+      :ownertype="ownertype"
+      :ownername="ownername"
+      :projectref="projectref"
+    />
 
     <div class="mb-8">
-      <span class="text-3xl">{{projectName()}}</span>
+      <span class="text-3xl">{{ projectName() }}</span>
     </div>
 
-    <div class="flex justify-between">
-      <ul class="flex-grow tab">
-        <li class="tab-element-disabled">
-          <i class="mr-1 mdi mdi-run-fast" />
-          <span>Runs</span>
-        </li>
-        <li>
-          <tabarrow />
-        </li>
-        <li
-          class="tab-element"
-          :class="[{ 'tab-element-selected': $route.name.match('project runs') || $route.name.endsWith('project') }]"
-        >
-          <router-link :to="projectRunsLink(ownertype, ownername, projectref)">
-            <i class="mr-1 mdi mdi-asterisk" />
-            <span>All</span>
-          </router-link>
-        </li>
-        <li
-          class="tab-element"
-          :class="[{ 'tab-element-selected': $route.name.match('project branches runs') }]"
-        >
-          <router-link :to="projectBranchesRunsLink(ownertype, ownername, projectref)">
-            <i class="mr-1 mdi mdi-source-branch" />
-            <span>Branches</span>
-          </router-link>
-        </li>
-        <li
-          class="tab-element"
-          :class="[{ 'tab-element-selected': $route.name.match('project tags runs') }]"
-        >
-          <router-link :to="projectTagsRunsLink(ownertype, ownername, projectref)">
-            <i class="mr-1 mdi mdi-tag" />
-            <span>Tags</span>
-          </router-link>
-        </li>
-        <li
-          class="tab-element"
-          :class="[{ 'tab-element-selected': $route.name.match('project pull requests runs') }]"
-        >
-          <router-link :to="projectPRsRunsLink(ownertype, ownername, projectref)">
-            <i class="mr-1 mdi mdi-source-pull" />
-            <span>Pull Requests</span>
-          </router-link>
-        </li>
-        <li
-          v-if="run && ($route.name.endsWith('project run') || $route.name.endsWith('project run task'))"
-        >
-          <tabarrow />
-        </li>
-        <li
-          class="tab-element"
-          v-if="run && ($route.name.endsWith('project run') || $route.name.endsWith('project run task'))"
-          :class="[{ 'tab-element-selected': $route.name.endsWith('project run') }]"
-        >
-          <router-link :to="projectRunLink(ownertype, ownername, projectref, $route.params.runid)">
-            <p>
-              Run
-              <strong>#{{run.counter}}</strong>
-            </p>
-          </router-link>
-        </li>
-        <li v-if="run && $route.name.endsWith('project run task')">
-          <tabarrow />
-        </li>
-        <li
-          class="tab-element"
-          v-if="run && $route.name.endsWith('project run task')"
-          :class="[{ 'tab-element-selected': $route.name.endsWith('project run task') }]"
-        >
-          <router-link
-            :to="projectRunTaskLink(ownertype, ownername, projectref, $route.params.runid, $route.params.taskid)"
+    <div class="flex justify-between border-b-2">
+      <nav>
+        <ul class="flex flex-wrap tab">
+          <li class="tab-element-disabled">
+            <i class="mr-1 mdi mdi-run-fast" />
+            <span>Runs</span>
+          </li>
+          <li>
+            <tabarrow />
+          </li>
+          <li
+            class="tab-element"
+            :class="[
+              {
+                'tab-element-selected':
+                  $route.name.match('project runs') ||
+                  $route.name.endsWith('project')
+              }
+            ]"
           >
-            <p>
-              Task
-              <strong>{{run.tasks[$route.params.taskid].name}}</strong>
-            </p>
-          </router-link>
-        </li>
-        <li
-          v-if="$route.name.endsWith('project settings')"
-          class="tab-element"
-          :class="[{ 'tab-element-selected': $route.name.endsWith('project settings') }]"
+            <router-link
+              :to="projectRunsLink(ownertype, ownername, projectref)"
+            >
+              <i class="mr-1 mdi mdi-asterisk" />
+              <span>All</span>
+            </router-link>
+          </li>
+          <li
+            class="tab-element pl-4"
+            :class="[
+              {
+                'tab-element-selected': $route.name.match(
+                  'project branches runs'
+                )
+              }
+            ]"
+          >
+            <router-link
+              :to="projectBranchesRunsLink(ownertype, ownername, projectref)"
+            >
+              <i class="mr-1 mdi mdi-source-branch" />
+              <span>Branches</span>
+            </router-link>
+          </li>
+          <li
+            class="tab-element pl-4"
+            :class="[
+              { 'tab-element-selected': $route.name.match('project tags runs') }
+            ]"
+          >
+            <router-link
+              :to="projectTagsRunsLink(ownertype, ownername, projectref)"
+            >
+              <i class="mr-1 mdi mdi-tag" />
+              <span>Tags</span>
+            </router-link>
+          </li>
+          <li
+            class="tab-element pl-4"
+            :class="[
+              {
+                'tab-element-selected': $route.name.match(
+                  'project pull requests runs'
+                )
+              }
+            ]"
+          >
+            <router-link
+              :to="projectPRsRunsLink(ownertype, ownername, projectref)"
+            >
+              <i class="mr-1 mdi mdi-source-pull" />
+              <span>Pull Requests</span>
+            </router-link>
+          </li>
+          <li
+            v-if="
+              run &&
+                ($route.name.endsWith('project run') ||
+                  $route.name.endsWith('project run task'))
+            "
+          >
+            <tabarrow />
+          </li>
+          <li
+            class="tab-element"
+            v-if="
+              run &&
+                ($route.name.endsWith('project run') ||
+                  $route.name.endsWith('project run task'))
+            "
+            :class="[
+              { 'tab-element-selected': $route.name.endsWith('project run') }
+            ]"
+          >
+            <router-link
+              :to="
+                projectRunLink(
+                  ownertype,
+                  ownername,
+                  projectref,
+                  $route.params.runid
+                )
+              "
+            >
+              <p>
+                Run
+                <strong>#{{ run.counter }}</strong>
+              </p>
+            </router-link>
+          </li>
+          <li v-if="run && $route.name.endsWith('project run task')">
+            <tabarrow />
+          </li>
+          <li
+            class="tab-element"
+            v-if="run && $route.name.endsWith('project run task')"
+            :class="[
+              {
+                'tab-element-selected': $route.name.endsWith('project run task')
+              }
+            ]"
+          >
+            <router-link
+              :to="
+                projectRunTaskLink(
+                  ownertype,
+                  ownername,
+                  projectref,
+                  $route.params.runid,
+                  $route.params.taskid
+                )
+              "
+            >
+              <p>
+                Task
+                <strong>{{ run.tasks[$route.params.taskid].name }}</strong>
+              </p>
+            </router-link>
+          </li>
+          <li
+            v-if="$route.name.endsWith('project settings')"
+            class="tab-element"
+            :class="[
+              {
+                'tab-element-selected': $route.name.endsWith('project settings')
+              }
+            ]"
+          >
+            <router-link
+              :to="projectSettingsLink(ownertype, ownername, projectref)"
+            >
+              <i class="mr-1 mdi mdi-settings" />
+              <span>Project Settings</span>
+            </router-link>
+          </li>
+        </ul>
+      </nav>
+      <nav>
+        <div
+          class="-mt-3"
+          v-click-outside="() => (dropdownActive = false)"
+          @click="dropdownActive = !dropdownActive"
         >
-          <router-link :to="projectSettingsLink(ownertype, ownername, projectref)">
-            <i class="mr-1 mdi mdi-settings" />
-            <span>Project Settings</span>
-          </router-link>
-        </li>
-      </ul>
-      <ul class="flex tab">
-        <li>
-          <div class="relative">
-            <div
-              class="flex -mt-3"
-              v-click-outside="() => dropdownActive = false"
-              @click="dropdownActive = !dropdownActive"
-            >
-              <button
-                class="relative flex items-center focus:outline-none bg-transparent hover:bg-gray-300 text-dark font-semibold hover:text-dark py-1 px-4 border border-gray-500 rounded"
+          <button
+            class="relative flex items-center focus:outline-none bg-transparent hover:bg-gray-300 text-dark font-semibold hover:text-dark py-1 px-4 border border-gray-500 rounded"
+          >
+            <i class="mr-4 mdi mdi-settings" />
+            <i class="mdi mdi-chevron-down"></i>
+          </button>
+        </div>
+        <div
+          v-if="dropdownActive"
+          class="z-10 origin-top-right absolute right-0 mt-2 w-64 bg-white rounded-lg border shadow-md py-2"
+        >
+          <ul>
+            <li>
+              <router-link
+                class="block px-4 py-2 hover:bg-blue-500 hover:text-white"
+                :to="projectSettingsLink(ownertype, ownername, projectref)"
               >
-                <i class="mr-4 mdi mdi-settings" />
-                <i class="mdi mdi-chevron-down"></i>
-              </button>
-            </div>
-            <div
-              v-if="dropdownActive"
-              class="z-10 origin-top-right absolute right-0 mt-2 w-64 bg-white rounded-lg border shadow-md py-2"
-            >
-              <ul>
-                <li>
-                  <router-link
-                    class="block px-4 py-2 hover:bg-blue-500 hover:text-white"
-                    :to="projectSettingsLink(ownertype, ownername, projectref)"
-                  >
-                    <i class="mr-1 mdi mdi-settings" />
-                    <span>Project Settings</span>
-                  </router-link>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </li>
-      </ul>
+                <i class="mr-1 mdi mdi-settings" />
+                <span>Project Settings</span>
+              </router-link>
+            </li>
+          </ul>
+        </div>
+      </nav>
     </div>
     <router-view class="mt-8"></router-view>
   </div>

--- a/src/views/ProjectGroup.vue
+++ b/src/views/ProjectGroup.vue
@@ -8,66 +8,90 @@
     />
 
     <div class="mb-8 flex justify-between">
-      <span class="text-3xl">{{projectGroupName()}}</span>
+      <span class="text-3xl">{{ projectGroupName() }}</span>
       <createprojectbutton v-on:click="goToCreate($event)" />
     </div>
 
-    <div class="flex justify-between">
-      <ul class="flex-grow tab">
-        <li
-          class="tab-element"
-          :class="[{ 'tab-element-selected': $route.name.match('project group project') || $route.name.endsWith('project group') }]"
-        >
-          <router-link :to="projectGroupProjectsLink(ownertype, ownername, projectgroupref)">
-            <i class="mdi mdi-home" />
-            <span>Projects</span>
-          </router-link>
-        </li>
-        <li
-          v-if="$route.name.endsWith('project group settings')"
-          class="tab-element"
-          :class="[{ 'tab-element-selected': $route.name.endsWith('project group settings') }]"
-        >
-          <router-link :to="projectGroupSettingsLink(ownertype, ownername, projectgroupref)">
-            <i class="mdi mdi-settings" />
-            <span>Project Group Settings</span>
-          </router-link>
-        </li>
-      </ul>
-      <ul class="flex tab">
-        <li>
-          <div class="relative">
-            <div
-              class="flex -mt-3"
-              v-click-outside="() => dropdownActive = false"
-              @click="dropdownActive = !dropdownActive"
+    <div class="flex justify-between border-b-2">
+      <nav>
+        <ul class="flex flex-wrap tab">
+          <li
+            class="tab-element"
+            :class="[
+              {
+                'tab-element-selected':
+                  $route.name.match('project group project') ||
+                  $route.name.endsWith('project group')
+              }
+            ]"
+          >
+            <router-link
+              :to="
+                projectGroupProjectsLink(ownertype, ownername, projectgroupref)
+              "
             >
-              <button
-                class="relative flex items-center focus:outline-none bg-transparent hover:bg-gray-300 text-dark font-semibold hover:text-dark py-1 px-4 border border-gray-500 rounded"
+              <i class="mdi mdi-home" />
+              <span>Projects</span>
+            </router-link>
+          </li>
+          <li
+            v-if="$route.name.endsWith('project group settings')"
+            class="tab-element"
+            :class="[
+              {
+                'tab-element-selected': $route.name.endsWith(
+                  'project group settings'
+                )
+              }
+            ]"
+          >
+            <router-link
+              :to="
+                projectGroupSettingsLink(ownertype, ownername, projectgroupref)
+              "
+            >
+              <i class="mdi mdi-settings" />
+              <span>Project Group Settings</span>
+            </router-link>
+          </li>
+        </ul>
+      </nav>
+      <nav>
+        <div
+          class="flex -mt-3"
+          v-click-outside="() => (dropdownActive = false)"
+          @click="dropdownActive = !dropdownActive"
+        >
+          <button
+            class="relative flex items-center focus:outline-none bg-transparent hover:bg-gray-300 text-dark font-semibold hover:text-dark py-1 px-4 border border-gray-500 rounded"
+          >
+            <i class="mr-4 mdi mdi-settings" />
+            <i class="mdi mdi-chevron-down"></i>
+          </button>
+        </div>
+        <div
+          v-if="dropdownActive"
+          class="z-10 origin-top-right absolute right-0 mt-2 w-64 bg-white rounded-lg border shadow-md py-2"
+        >
+          <ul>
+            <li>
+              <router-link
+                class="block px-4 py-2 hover:bg-blue-500 hover:text-white"
+                :to="
+                  projectGroupSettingsLink(
+                    ownertype,
+                    ownername,
+                    projectgroupref
+                  )
+                "
               >
-                <i class="mr-4 mdi mdi-settings" />
-                <i class="mdi mdi-chevron-down"></i>
-              </button>
-            </div>
-            <div
-              v-if="dropdownActive"
-              class="z-10 origin-top-right absolute right-0 mt-2 w-64 bg-white rounded-lg border shadow-md py-2"
-            >
-              <ul>
-                <li>
-                  <router-link
-                    class="block px-4 py-2 hover:bg-blue-500 hover:text-white"
-                    :to="projectGroupSettingsLink(ownertype, ownername, projectgroupref)"
-                  >
-                    <i class="mdi mdi-settings" />
-                    <span>Project Group Settings</span>
-                  </router-link>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </li>
-      </ul>
+                <i class="mdi mdi-settings" />
+                <span>Project Group Settings</span>
+              </router-link>
+            </li>
+          </ul>
+        </div>
+      </nav>
     </div>
     <router-view class="mt-8"></router-view>
   </div>

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -9,125 +9,158 @@
           <span class="mx-2">/</span>
         </li>
         <li>
-          <router-link :to="ownerLink('user', username)">{{username}}</router-link>
+          <router-link :to="ownerLink('user', username)">{{
+            username
+          }}</router-link>
         </li>
       </ol>
     </nav>
 
     <div class="mb-8 flex justify-between">
-      <span class="text-3xl">{{username}}</span>
+      <span class="text-3xl">{{ username }}</span>
       <createprojectbutton v-on:click="goToCreate($event)" />
     </div>
 
-    <div class="flex justify-between">
-      <ul class="flex-grow tab">
-        <li
-          class="tab-element"
-          :class="[{ 'tab-element-selected': $route.name === 'user projects' || $route.name === 'user' }]"
-        >
-          <router-link :to="ownerProjectsLink('user', username)">
-            <i class="mr-1 mdi mdi-home" />
-            <span>Projects</span>
-          </router-link>
-        </li>
-        <li
-          class="tab-element"
-          :class="[{ 'tab-element-selected': $route.name === 'user direct runs' }]"
-        >
-          <router-link :to="userDirectRunsLink(username)">
-            <i class="mr-1 mdi mdi-run-fast" />
-            <span>Direct Runs</span>
-          </router-link>
-        </li>
-        <li
-          v-if="run && ($route.name === 'user direct run' || $route.name == 'user direct run task')"
-        >
-          <tabarrow />
-        </li>
-        <li
-          class="tab-element"
-          v-if="run && ($route.name === 'user direct run' || $route.name == 'user direct run task')"
-          :class="[{ 'tab-element-selected': $route.name === 'user direct run' }]"
-        >
-          <router-link :to="userDirectRunLink(username, $route.params.runid)">
-            <span>
-              Run
-              <strong>#{{run.counter}}</strong>
-            </span>
-          </router-link>
-        </li>
-        <li v-if="run && $route.name === 'user direct run task'">
-          <tabarrow />
-        </li>
-        <li
-          class="tab-element"
-          v-if="run && $route.name == 'user direct run task'"
-          :class="[{ 'tab-element-selected': $route.name === 'user direct run task' }]"
-        >
-          <router-link
-            :to="userDirectRunTaskLink(username, $route.params.runid, $route.params.taskid)"
+    <div class="flex justify-between border-b-2">
+      <nav>
+        <ul class="flex flex-wrap tab">
+          <li
+            class="tab-element"
+            :class="[
+              {
+                'tab-element-selected':
+                  $route.name === 'user projects' || $route.name === 'user'
+              }
+            ]"
           >
-            <span>
-              Task
-              <strong>{{run.tasks[$route.params.taskid].name}}</strong>
-            </span>
-          </router-link>
-        </li>
-        <li
-          v-if="$route.name.endsWith('user project group settings')"
-          class="tab-element"
-          :class="[{ 'tab-element-selected': $route.name.endsWith('user project group settings') }]"
-        >
-          <router-link :to="projectGroupSettingsLink('user', username, [])">
-            <i class="mr-1 mdi mdi-settings" />
-            <span>Root Project Group Settings</span>
-          </router-link>
-        </li>
-        <li
-          v-if="$route.name.endsWith('user settings')"
-          class="tab-element"
-          :class="[{ 'tab-element-selected': $route.name.endsWith('user settings') }]"
-        >
-          <router-link :to="ownerSettingsLink('user', username)">
-            <i class="mr-1 mdi mdi-settings" />
-            <span>User Settings</span>
-          </router-link>
-        </li>
-      </ul>
-      <ul class="flex tab">
-        <li>
-          <div class="relative">
-            <div
-              class="flex -mt-3"
-              v-click-outside="() => dropdownActive = false"
-              @click="dropdownActive = !dropdownActive"
+            <router-link :to="ownerProjectsLink('user', username)">
+              <i class="mr-1 mdi mdi-home" />
+              <span>Projects</span>
+            </router-link>
+          </li>
+          <li
+            class="tab-element pl-4"
+            :class="[
+              { 'tab-element-selected': $route.name === 'user direct runs' }
+            ]"
+          >
+            <router-link :to="userDirectRunsLink(username)">
+              <i class="mr-1 mdi mdi-run-fast" />
+              <span>Direct Runs</span>
+            </router-link>
+          </li>
+          <li
+            v-if="
+              run &&
+                ($route.name === 'user direct run' ||
+                  $route.name == 'user direct run task')
+            "
+          >
+            <tabarrow />
+          </li>
+          <li
+            class="tab-element"
+            v-if="
+              run &&
+                ($route.name === 'user direct run' ||
+                  $route.name == 'user direct run task')
+            "
+            :class="[
+              { 'tab-element-selected': $route.name === 'user direct run' }
+            ]"
+          >
+            <router-link :to="userDirectRunLink(username, $route.params.runid)">
+              <span>
+                Run
+                <strong>#{{ run.counter }}</strong>
+              </span>
+            </router-link>
+          </li>
+          <li v-if="run && $route.name === 'user direct run task'">
+            <tabarrow />
+          </li>
+          <li
+            class="flex-shrink tab-element"
+            v-if="run && $route.name == 'user direct run task'"
+            :class="[
+              { 'tab-element-selected': $route.name === 'user direct run task' }
+            ]"
+          >
+            <router-link
+              :to="
+                userDirectRunTaskLink(
+                  username,
+                  $route.params.runid,
+                  $route.params.taskid
+                )
+              "
             >
-              <button
-                class="relative flex items-center focus:outline-none bg-transparent hover:bg-gray-300 text-dark font-semibold hover:text-dark py-1 px-4 border border-gray-500 rounded"
+              <span white-space: nowrap>
+                Task
+                <strong>{{ run.tasks[$route.params.taskid].name }}</strong>
+              </span>
+            </router-link>
+          </li>
+          <li
+            v-if="$route.name.endsWith('user project group settings')"
+            class="tab-element"
+            :class="[
+              {
+                'tab-element-selected': $route.name.endsWith(
+                  'user project group settings'
+                )
+              }
+            ]"
+          >
+            <router-link :to="projectGroupSettingsLink('user', username, [])">
+              <i class="mr-1 mdi mdi-settings" />
+              <span>Root Project Group Settings</span>
+            </router-link>
+          </li>
+          <li
+            v-if="$route.name.endsWith('user settings')"
+            class="tab-element"
+            :class="[
+              { 'tab-element-selected': $route.name.endsWith('user settings') }
+            ]"
+          >
+            <router-link :to="ownerSettingsLink('user', username)">
+              <i class="mr-1 mdi mdi-settings" />
+              <span>User Settings</span>
+            </router-link>
+          </li>
+        </ul>
+      </nav>
+      <nav>
+        <div
+          class="flex -mt-3"
+          v-click-outside="() => (dropdownActive = false)"
+          @click="dropdownActive = !dropdownActive"
+        >
+          <button
+            class="relative flex items-center focus:outline-none bg-transparent hover:bg-gray-300 text-dark font-semibold hover:text-dark py-1 px-4 border border-gray-500 rounded"
+          >
+            <i class="mr-4 mdi mdi-settings" />
+            <i class="mdi mdi-chevron-down"></i>
+          </button>
+        </div>
+        <div
+          v-if="dropdownActive"
+          class="z-10 origin-top-right absolute right-0 mt-2 w-64 bg-white rounded-lg border shadow-md py-2"
+        >
+          <ul>
+            <li>
+              <router-link
+                class="block px-4 py-2 hover:bg-blue-500 hover:text-white"
+                :to="projectGroupSettingsLink('user', username, [])"
               >
-                <i class="mr-4 mdi mdi-settings" />
-                <i class="mdi mdi-chevron-down"></i>
-              </button>
-            </div>
-            <div
-              v-if="dropdownActive"
-              class="z-10 origin-top-right absolute right-0 mt-2 w-64 bg-white rounded-lg border shadow-md py-2"
-            >
-              <ul>
-                <li>
-                  <router-link
-                    class="block px-4 py-2 hover:bg-blue-500 hover:text-white"
-                    :to="projectGroupSettingsLink('user', username, [])"
-                  >
-                    <i class="mr-1 mdi mdi-settings" />
-                    <span>Root Project Group Settings</span>
-                  </router-link>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </li>
-      </ul>
+                <i class="mr-1 mdi mdi-settings" />
+                <span>Root Project Group Settings</span>
+              </router-link>
+            </li>
+          </ul>
+        </div>
+      </nav>
     </div>
     <router-view class="mt-8"></router-view>
   </div>


### PR DESCRIPTION
Make the tab elements wrap to a new line when too long (i.e. too long task
name).
Also simplify css for tabs.