### PR TITLE
Dockerfile: use fixed node image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine AS web_build
+FROM node:12-alpine AS web_build
 
 WORKDIR /agola-web
 


### PR DESCRIPTION
Fix it to node 12 until we migrate to new versions of tailwind, vue
etc...