### PR TITLE
router: make run and tasks route open to unauthenticated users

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -558,17 +558,7 @@ export const setupNavigationGuards = (
       auth.setLoginReturnPath();
     }
 
-    if (
-      !auth.authenticated.value &&
-      !['home', 'register', 'login', 'oauth2', 'newsource'].includes(
-        to.name?.toString() || ''
-      )
-    ) {
-      return { name: 'home' };
-    }
-
     const { path, query } = to;
-
     if (path == '/run') {
       // generic run handler by projectref and runnumber
       const projectref = query.projectref?.toString() || '';
@@ -592,6 +582,23 @@ export const setupNavigationGuards = (
         }
         appState.setGlobalError(e);
       }
+    }
+
+    if (
+      !auth.authenticated.value &&
+      ![
+        'home',
+        'register',
+        'login',
+        'oauth2',
+        'newsource',
+        'user project run',
+        'user project run task',
+        'org project run',
+        'org project run task',
+      ].includes(to.name?.toString() || '')
+    ) {
+      return { name: 'home' };
     }
   });
 };


### PR DESCRIPTION
restore the pre vue3 migration behavior of keeping runs and tasks views visibile also to non authenticated users.

We could also (like in pre vue3 migration) just don't filter any view since all the other will trigger some api calls returning a 401 unauthorized, but it's more explicit to directly filter them in the ui.