### PR TITLE
*: use shorthand ":" syntax for v-bind

### DIFF
--- a/src/components/createprojectgroup.vue
+++ b/src/components/createprojectgroup.vue
@@ -17,7 +17,7 @@
 
     <button
       class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-      v-bind:class="{ spinner: createProjectGroupLoading }"
+      :class="{ spinner: createProjectGroupLoading }"
       :disabled="!createProjectGroupButtonEnabled"
       @click="createProjectGroup()"
     >

--- a/src/components/projbreadcrumbs.vue
+++ b/src/components/projbreadcrumbs.vue
@@ -13,7 +13,7 @@
         }}</router-link>
       </li>
       <template v-if="projectref">
-        <li v-for="(ref, i) in projectref" v-bind:key="i">
+        <li v-for="(ref, i) in projectref" :key="i">
           <span class="mx-2">/</span>
           <router-link
             v-if="i + 1 < projectref.length"
@@ -31,7 +31,7 @@
       </template>
 
       <template v-if="projectgroupref">
-        <li v-for="(ref, i) in projectgroupref" v-bind:key="i">
+        <li v-for="(ref, i) in projectgroupref" :key="i">
           <span class="mx-2">/</span>
           <router-link
             :to="

--- a/src/components/projects.vue
+++ b/src/components/projects.vue
@@ -2,13 +2,13 @@
   <div>
     <h4 class="text-xl my-3">Projects</h4>
     <div v-if="!fetchedProjects" class="ml-6 flex w-48">
-      <div v-bind:class="{ spinner: !fetchedProjects }"></div>
+      <div :class="{ spinner: !fetchedProjects }"></div>
     </div>
     <ul v-else-if="projects && projects.length > 0">
       <li
         class="mb-2 border rounded-l"
         v-for="project in projects"
-        v-bind:key="project.id"
+        :key="project.id"
       >
         <div class="pl-4 py-4 flex items-center">
           <router-link
@@ -26,13 +26,13 @@
 
     <h4 class="text-xl my-3">Project Groups</h4>
     <div v-if="!fetchedProjectGroups" class="ml-6 flex w-48">
-      <div v-bind:class="{ spinner: !fetchedProjectGroups }"></div>
+      <div :class="{ spinner: !fetchedProjectGroups }"></div>
     </div>
     <ul v-else-if="projectGroups && projectGroups.length > 0">
       <li
         class="mb-2 border rounded-l"
         v-for="projectGroup in projectGroups"
-        v-bind:key="projectGroup.id"
+        :key="projectGroup.id"
       >
         <div class="pl-4 py-4 flex items-center">
           <router-link

--- a/src/components/remoterepos.vue
+++ b/src/components/remoterepos.vue
@@ -4,7 +4,7 @@
       <label
         class="block px-4 py-2 border-b"
         v-for="(repo, index) in remoterepos"
-        v-bind:key="repo.id"
+        :key="repo.id"
         @click="select(index)"
       >
         <input type="radio" :checked="selectedRepo == index" />

--- a/src/components/runs.vue
+++ b/src/components/runs.vue
@@ -9,14 +9,14 @@
     </div>
 
     <div v-if="!fetchedRuns && runs?.length == 0" class="ml-6 flex w-48">
-      <div v-bind:class="{ spinner: !fetchedRuns }"></div>
+      <div :class="{ spinner: !fetchedRuns }"></div>
     </div>
     <div v-if="runs">
       <ul>
         <li
           class="mb-2 border-l-5 rounded-l"
           v-for="run in runs"
-          v-bind:key="run.number"
+          :key="run.number"
           :class="runResultClass(run)"
         >
           <div class="pl-4 flex items-center border border-l-0 rounded-r">

--- a/src/components/runsummary.vue
+++ b/src/components/runsummary.vue
@@ -49,7 +49,7 @@
           <pre
             class="font-mono leading-snug text-xs"
             v-for="(error, i) in run.setupErrors"
-            v-bind:key="i"
+            :key="i"
             >{{ error }}</pre
           >
         </div>

--- a/src/components/secrets.vue
+++ b/src/components/secrets.vue
@@ -3,7 +3,7 @@
     <div class="my-3 flex font-bold">
       <div class="w-2/12">Name</div>
     </div>
-    <div class="flex" v-for="secret in secrets" v-bind:key="secret.id">
+    <div class="flex" v-for="secret in secrets" :key="secret.id">
       <div class="w-2/12">
         <span class="name">{{ secret.name }}</span>
         <div v-if="showparentpath" class="text-sm font-light">

--- a/src/components/tasks.vue
+++ b/src/components/tasks.vue
@@ -1,6 +1,6 @@
 <template>
   <ul>
-    <li v-for="task in sortedTasks" v-bind:key="task.id">
+    <li v-for="task in sortedTasks" :key="task.id">
       <div class="mb-2 border-l-5 rounded-l" :class="taskClass(task)">
         <div
           class="px-4 py-4 flex justify-between items-center border border-l-0 rounded-r"
@@ -23,7 +23,7 @@
               <li
                 class="font-thin text-xs text-gray-600"
                 v-for="dep in task.parents"
-                v-bind:key="dep"
+                :key="dep"
               >
                 {{ dep }}
               </li>

--- a/src/components/tasksgraph.vue
+++ b/src/components/tasksgraph.vue
@@ -9,7 +9,7 @@
       scroll
       overflow="scroll"
     >
-      <g v-for="(segment, i) in segments" v-bind:key="i">
+      <g v-for="(segment, i) in segments" :key="i">
         <line
           :x1="segment.x1"
           :y1="segment.y1"
@@ -21,7 +21,7 @@
           :class="['stroke-current', segment.stroke]"
         />
       </g>
-      <g v-for="(task, idx) in outTasks" v-bind:key="idx">
+      <g v-for="(task, idx) in outTasks" :key="idx">
         <foreignObject
           :x="(taskWidth + taskXSpace) * task.level"
           :y="(taskHeight + taskYSpace) * task.row"

--- a/src/components/tasksummary.vue
+++ b/src/components/tasksummary.vue
@@ -49,21 +49,21 @@
       </div>
       <step
         v-if="task.setupStep"
-        v-bind:rungrouptype="rungrouptype"
-        v-bind:rungroupref="rungroupref"
-        v-bind:runnumber="runnumber"
-        v-bind:taskid="taskid"
-        v-bind:setup="true"
-        v-bind:step="task.setupStep"
+        :rungrouptype="rungrouptype"
+        :rungroupref="rungroupref"
+        :runnumber="runnumber"
+        :taskid="taskid"
+        :setup="true"
+        :step="task.setupStep"
       />
-      <div v-for="(step, index) in task.steps" v-bind:key="index">
+      <div v-for="(step, index) in task.steps" :key="index">
         <step
-          v-bind:rungrouptype="rungrouptype"
-          v-bind:rungroupref="rungroupref"
-          v-bind:runnumber="runnumber"
-          v-bind:taskid="taskid"
-          v-bind:stepnum="index"
-          v-bind:step="step"
+          :rungrouptype="rungrouptype"
+          :rungroupref="rungroupref"
+          :runnumber="runnumber"
+          :taskid="taskid"
+          :stepnum="index"
+          :step="step"
         />
       </div>
     </div>

--- a/src/components/vars.vue
+++ b/src/components/vars.vue
@@ -16,7 +16,7 @@
         </div>
       </div>
     </div>
-    <div class="flex" v-for="variable in variables" v-bind:key="variable.id">
+    <div class="flex" v-for="variable in variables" :key="variable.id">
       <div class="w-2/12">
         <span class="name">{{ variable.name }}</span>
         <div v-if="showparentpath" class="text-sm font-light">
@@ -24,7 +24,7 @@
         </div>
       </div>
       <div class="w-10/12">
-        <div class="flex" v-for="(val, i) in variable.values" v-bind:key="i">
+        <div class="flex" v-for="(val, i) in variable.values" :key="i">
           <div class="w-2/12">
             <span>{{ val.secretName }}</span>
             <div v-if="val.matchingSecretParentPath" class="text-sm">
@@ -39,7 +39,7 @@
             <div v-if="val.when">
               <div
                 v-for="whenCondition in getWhenConditions(val.when)"
-                v-bind:key="whenCondition.condType"
+                :key="whenCondition.condType"
               >
                 <div v-if="whenCondition.cond">
                   <div class="flex">
@@ -49,7 +49,7 @@
                     <div class="w-1/3">
                       <div
                         v-for="include in whenCondition.cond.include"
-                        v-bind:key="include.match"
+                        :key="include.match"
                       >
                         <div>{{ include.match }}</div>
                       </div>
@@ -57,7 +57,7 @@
                     <div class="w-1/3">
                       <div
                         v-for="exclude in whenCondition.cond.exclude"
-                        v-bind:key="exclude.match"
+                        :key="exclude.match"
                       >
                         <div>{{ exclude.match }}</div>
                       </div>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -27,7 +27,7 @@
         <div
           class="my-6 flex justify-center items-center"
           v-for="rs in remoteSources"
-          v-bind:key="rs.id"
+          :key="rs.id"
         >
           <div v-if="rs.loginEnabled">
             <LoginForm

--- a/src/views/Register.vue
+++ b/src/views/Register.vue
@@ -46,7 +46,7 @@
         <div
           class="my-6 flex justify-center items-center"
           v-for="rs in remoteSources"
-          v-bind:key="rs.id"
+          :key="rs.id"
         >
           <div v-if="rs.registrationEnabled">
             <LoginForm


### PR DESCRIPTION
Remove some old remaining v-bind and use instead the shorthand ":" syntax.