### PR TITLE
ci: update node versions

### DIFF
--- a/.agola/config.jsonnet
+++ b/.agola/config.jsonnet
@@ -33,7 +33,7 @@ local task_build(version, arch) = {
         [
           task_build(version, arch),
         ]
-        for version in ['16', '18']
+        for version in ['18', '20']
         for arch in ['amd64']
       ]) + [
         {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine AS web_build
+FROM node:20-alpine AS web_build
 
 WORKDIR /agola-web
 


### PR DESCRIPTION
Use node version 18 and 20 since version 20 is the currently active, 18 is in maintenance and 16 is in end of life.

Use node version 20 as base Dockerfile image.