### PR TITLE
Dockerfile: copy pnpm-lock.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /agola-web
 
 RUN npm install -g pnpm
 
-# copy both 'package.json' and 'package-lock.json' (if available)
-COPY package*.json ./
+# copy both 'package.json' and 'pnpm-lock.yaml' (if available)
+COPY package.json pnpm-lock.yaml ./
 COPY stub/ ./stub/
 
 # install project dependencies


### PR DESCRIPTION
After migrating to pnpm the pnpm-lock.yaml wasn't added in the Dockerfile to the files to copy from the source code before doing a pnpm install. So newer package versions could be installed and used to build the image.

Copy the lock file to ensure reproducible builds.