### PR TITLE
*: use improved common name validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "tslib": "^2.6.2",
     "typedjson": "^1.8.0",
     "universal-cookie": "^7.1.0",
+    "uuidjs": "^5.0.1",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ dependencies:
   universal-cookie:
     specifier: ^7.1.0
     version: 7.1.0
+  uuidjs:
+    specifier: ^5.0.1
+    version: 5.0.1
   vue:
     specifier: ^3.4.21
     version: 3.4.21(typescript@5.4.2)
@@ -3163,6 +3166,11 @@ packages:
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
+
+  /uuidjs@5.0.1:
+    resolution: {integrity: sha512-W9ea6Rj0L4P7YyLpUYqDoqoBEH7AP1NshTYqXeAs9GoK3ynWco9VkWGzV7aqWjCyFEBbPgCCIBKiTJXOmlTTag==}
+    hasBin: true
+    dev: false
 
   /v8-to-istanbul@9.2.0:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}

--- a/src/components/createupdatesecret.vue
+++ b/src/components/createupdatesecret.vue
@@ -116,15 +116,13 @@ import { useRouter } from 'vue-router';
 import { ApiError, errorToString, useAPI } from '../app/api';
 import { useAppState } from '../app/appstate';
 import { projectGroupSettingsLink, projectSettingsLink } from '../util/link';
-import { isValid } from '../util/validator';
+import { isValid, isValidName } from '../util/validator';
 
 interface SecretValues {
   key: string;
   value: string;
   error: string | undefined;
 }
-
-const secretNameRegExp = /^[a-zA-Z][a-zA-Z0-9]*([-]?[a-zA-Z0-9]+)+$/;
 
 export default {
   name: 'createupdatesecret',
@@ -262,8 +260,8 @@ export default {
 
       if (!secretName.value) {
         return 'Secret name is required';
-      } else if (!secretNameRegExp.test(secretName.value)) {
-        return 'Secret name cannot contain special chars or spaces';
+      } else if (!isValidName(secretName.value)) {
+        return 'Secret name can only contain alphanumeric ASCII chars and optionally some single hypens in the middle';
       } else if (!secretNameUnique) {
         return 'Secret with the specified name already exists';
       }

--- a/src/components/createupdatevariable.vue
+++ b/src/components/createupdatevariable.vue
@@ -251,7 +251,7 @@ import {
 import { useAppState } from '../app/appstate';
 import { OperationType } from '../app/types';
 import { projectGroupSettingsLink, projectSettingsLink } from '../util/link';
-import { isValid } from '../util/validator';
+import { isValid, isValidName } from '../util/validator';
 
 interface VariableValue {
   secretName: string;
@@ -319,8 +319,6 @@ export default {
     const variableNameError: Ref<string | undefined> = ref();
 
     const createVariableError: Ref<unknown | undefined> = ref();
-    const variableNameRegExp = /^[a-zA-Z][a-zA-Z0-9]*([-]?[a-zA-Z0-9]+)+$/;
-    const regexMatchErrorMessage = ref('');
     let fetchAbort = new AbortController();
 
     onUnmounted(() => {
@@ -415,8 +413,8 @@ export default {
 
       if (!variableName.value) {
         return 'Variable name is required';
-      } else if (!variableNameRegExp.test(variableName.value)) {
-        return 'Variable name cannot contain special chars or spaces';
+      } else if (!isValidName(variableName.value)) {
+        return 'Variable name can only contain alphanumeric ASCII chars and optionally some single hypens in the middle';
       } else if (!varNameUnique) {
         return 'Variable with the specified name already exists';
       }
@@ -429,7 +427,7 @@ export default {
     const variableSecretNameValidator = (variable: VariableValue) => {
       if (!variable.secretName) {
         return 'Secret name is required.';
-      } else if (!variableNameRegExp.test(variable.secretName)) {
+      } else if (!isValidName(variable.secretName)) {
         return 'Secret name cannot contain special chars or spaces';
       }
     };
@@ -666,7 +664,6 @@ export default {
     return {
       variableName,
       variableNameError,
-      regexMatchErrorMessage,
       createVariableError,
       isSaveButtonDisabled,
 

--- a/src/util/validator.test.ts
+++ b/src/util/validator.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'vitest';
+import { isValidName } from './validator';
+
+test.each([
+  // good names
+  ['0', true],
+  ['a', true],
+  ['Z', true],
+  ['bar', true],
+  ['foo-bar', true],
+  ['foo-bar-baz', true],
+  ['foo1', true],
+  ['foo-1', true],
+  ['foo-1-bar', true],
+  ['f12oo-bar33', true],
+  ['cba7b810-9dad-11d1-80b4-00c04fd430c', true],
+  ['cba7b810-9dad-11d1-80b4000c04fd430c8', true],
+  ['cba7b8109dad11d180b400c04fd430c89', true],
+  ['cba7b8109dad11d180b400c04fd430c', true],
+
+  // bad names
+  ['', false],
+  ['-', false],
+  ['È', false],
+  ['Èà', false],
+  ['foo bar', false],
+  [' foo bar', false],
+  ['foo bar ', false],
+  ['-bar', false],
+  ['bar-', false],
+  ['-foo-bar', false],
+  ['foo-bar-', false],
+  ['foo--bar', false],
+  ['foo.bar', false],
+  ['foo_bar', false],
+  ['foo#bar', false],
+  ['1foobar', false],
+  ['cba7b810-9dad-11d1-80b4-00c04fd430c8', false], // uuid
+  ['{cba7b810-9dad-11d1-80b4-00c04fd430c8}', false], // uuid
+  ['urn:uuid:cba7b810-9dad-11d1-80b4-00c04fd430c8', false], // uuid
+  ['cba7b8109dad11d180b400c04fd430c8', false], // uuid
+  ['abcdefghijklmnopqrstuvwxyz0123456789abcde', false], // 41 ascii chars length
+])('%s is valid name -> %s', (name, expected) => {
+  expect(isValidName(name)).toBe(expected);
+});

--- a/src/util/validator.ts
+++ b/src/util/validator.ts
@@ -1,3 +1,40 @@
+import { UUID } from 'uuidjs';
+
 export function isValid(validatorResult: string | undefined): boolean {
   return !validatorResult;
+}
+
+const minNameCharacters = 1;
+const maxNameCharacters = 40;
+
+function charsCount(s: string): number {
+  return [...s].length;
+}
+
+const singleCharNameRegexp = /^[a-zA-Z0-9]$/;
+const nameRegExp = /^[a-zA-Z][a-zA-Z0-9]*([-]?[a-zA-Z0-9]+)+$/;
+
+export function isValidName(name: string): boolean {
+  const c = charsCount(name);
+
+  // also handle uuid in hash format (without dashes)
+  if (c == 32) {
+    name = name.slice(0, 20) + '-' + name.slice(20);
+    name = name.slice(0, 16) + '-' + name.slice(16);
+    name = name.slice(0, 12) + '-' + name.slice(12);
+    name = name.slice(0, 8) + '-' + name.slice(8);
+  }
+
+  const uuid = UUID.parse(name);
+  if (uuid) return false;
+
+  if (c < minNameCharacters || c > maxNameCharacters) {
+    return false;
+  }
+
+  if (c == 1) {
+    return singleCharNameRegexp.test(name);
+  }
+
+  return nameRegExp.test(name);
 }


### PR DESCRIPTION
Use an improved common name validator function

The new name validator will behave the same as the backend name validator.
Add tests to the validator with the same checks done in the backend.