### PR TITLE
*: improve/fix login handling

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -841,7 +841,8 @@ export const setupNavigationGuards = (
         'org project run task',
       ].includes(to.name?.toString() || '')
     ) {
-      return { name: 'home' };
+      auth.setLoginReturnPath(path);
+      return { name: 'login' };
     }
   });
 };


### PR DESCRIPTION
* If an unauthenticated user tries to land on a route that requires auth, save the route and go to the login view. The current route will be restored after successful login.
* If an api call returns a 401 (unauthorized), logout the user and do the same as above. This happens when an user is authenticated but the cookie expires.