### PR TITLE
api: handle AbortError in handleFetchError

### DIFF
--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -578,18 +578,18 @@ export function newAPI(): API {
         throw new APIError(res.status);
       }
 
-      let detailedErrors;
       try {
-        detailedErrors = JSON.parse(await res.text());
+        const detailedErrors = JSON.parse(await res.text());
+        throw new APIError(res.status, detailedErrors);
       } catch (e) {
-        // not a json response
-        throw new APIError(res.status, detailedErrors);
-      }
+        if (e instanceof DOMException) {
+          if (e.name == 'AbortError') throw new APIAbortedError();
+        }
 
-      if (detailedErrors) {
-        throw new APIError(res.status, detailedErrors);
+        if (e instanceof APIError) throw e;
+
+        throw new APIError(res.status);
       }
-      throw new APIError(res.status);
     }
   }
 
@@ -667,6 +667,7 @@ export function newAPI(): API {
         if (e.name == 'AbortError') throw new APIAbortedError();
       }
 
+      if (e instanceof APIAbortedError) throw e;
       if (e instanceof APIError) throw e;
 
       throw new APIError();

--- a/src/components/createupdatesecret.test.ts
+++ b/src/components/createupdatesecret.test.ts
@@ -608,5 +608,5 @@ test('error response from the server is correctly displayed', async () => {
   expect(wrapper.router.push).not.toHaveBeenCalled();
 
   const serverError = wrapper.find('[data-test="serverError"]');
-  expect(serverError.text()).toContain('Project group does not exist');
+  expect(serverError.text()).toBe('Project group does not exist');
 });

--- a/src/components/createupdatevariable.test.ts
+++ b/src/components/createupdatevariable.test.ts
@@ -788,5 +788,5 @@ test('error response from the server is correctly displayed', async () => {
   expect(wrapper.router.push).not.toHaveBeenCalled();
 
   const serverError = wrapper.find('[data-test="serverError"]');
-  expect(serverError.text()).toContain('Project group does not exist');
+  expect(serverError.text()).toBe('Project group does not exist');
 });


### PR DESCRIPTION
await res.text() could throw an AbortError that should be handled and rethrown as an APIAbortedError.